### PR TITLE
Update Utils.js to fix chat.isReadOnly

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -460,6 +460,7 @@ exports.LoadUtils = () => {
             const chatWid = window.Store.WidFactory.createWid((chat.id._serialized));
             await window.Store.GroupMetadata.update(chatWid);
             res.groupMetadata = chat.groupMetadata.serialize();
+            res.isReadOnly = chat.groupMetadata.announce;
         }
         
         res.lastMessage = null;


### PR DESCRIPTION
# PR Details

This PR fixed the chat.isReadOnly attribute is always false

## Description

Fixing the chat.isReadOnly attribute.

## Motivation and Context

chat.isReadOnly was always false

## How Has This Been Tested

```
// client initialization...

client.on('ready', async () => {
    const groupChat = await client.getChatById("xxxxxxxxxxxxxxxxx@g.us");
    console.log(groupChat.isReadOnly);
});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#fix-chat.isReadOnly`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#fix-chat.isReadOnly`

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)