### PR TITLE
Fix addParticipants

### DIFF
--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -98,7 +98,7 @@ class GroupChat extends Chat {
                 419: 'The participant can\'t be added because the group is full'
             };
 
-            await window.Store.GroupQueryAndUpdate(groupWid);
+            await window.Store.GroupQueryAndUpdate({ id: groupId });
             const groupMetadata = group.groupMetadata;
             const groupParticipants = groupMetadata?.participants;
 


### PR DESCRIPTION
# PR Details

This PR fixed the groupChat.addParticipants attribute is always false

## Description

Fixing the groupChat.addParticipants method.

## Motivation and Context

groupChat.addParticipants error: Cannot read properties of undefined (reading 'toString')

## How Has This Been Tested

```
// client initialization...

client.on('ready', async () => {
    const groupChat = await client.getChatById("xxxxxxxxxxxxxxxxx@g.us");
    await group.addParticipants(['xxxxxxxxxxxx@c.us']);
});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#fix-groupChat-addParticipants`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#fix-groupChat-addParticipants`

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)