### PR TITLE
Adjustment addParticipants

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -942,12 +942,16 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.getAddParticipantsRpcResult = async (groupMetadata, groupWid, participantWid) => {
-        const participantLidArgs = groupMetadata?.isLidAddressingMode
+        const participantLidArgs = groupMetadata?.isLidAddressingMode && participantWid.server == 'lid'
             ? {
-                phoneNumber: participantWid,
-                lid: window.Store.LidUtils.getCurrentLid(participantWid)
+                phoneNumber: window.Store.LidUtils.getPhoneNumber(participantWid),
+                lid: participantWid
             }
-            : { phoneNumber: participantWid };
+            : { 
+                phoneNumber: participantWid.server == 'lid' 
+                    ? window.Store.LidUtils.getPhoneNumber(participantWid)
+                    : participantWid 
+            };
 
         const iqTo = window.Store.WidToJid.widToGroupJid(groupWid);
 


### PR DESCRIPTION
# PR Details

Adjustment addParticipants

## Description

People are struggling to add participants to groups isLidAddressingMode=true, and using @lid

## Related Issue(s)

https://github.com/pedroslopez/whatsapp-web.js/issues/3666

## Motivation and Context

<!-- Optional --->
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

```js
// client initialization...

client.on('ready', async () => {

    client.getChatById(groupId);
    const added = await groupChat.addParticipants(['xxxxx@c.us','xxxxx@lid']);
});
```

## You can try the fix by running one of the following commands:

- NPM
`npm install github:BenyFilho/whatsapp-web.js#addParticipants`

- YARN
`yarn add github:BenyFilho/whatsapp-web.js#addParticipants`


## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)